### PR TITLE
print parse exception

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -7,8 +7,8 @@ module MetadataJsonLint
 
     begin
       parsed = JSON.parse(f)
-    rescue
-      abort("Error: Unable to parse json. There is a syntax error somewhere.")
+    rescue Exception => e
+      abort("Error: Unable to parse metadata.json: #{e.exception}")
     end
 
     # Fields required to be in metadata.json


### PR DESCRIPTION
we have a hold on the parse exception, we should give it to our users,
rather than being vague

(not that the exception is of much use, tbh, but still a bit better than
nothing at all ;)
