### PR TITLE
Add rake task

### DIFF
--- a/lib/metadata-json-lint/rake_task.rb
+++ b/lib/metadata-json-lint/rake_task.rb
@@ -1,0 +1,11 @@
+require 'rake'
+require 'rake/tasklib'
+require 'metadata_json_lint'
+require 'json'
+
+desc 'Run metadata-json-lint'
+task :metadata_lint do
+  if File.exist?('metadata.json')
+    MetadataJsonLint.parse('metadata.json')
+  end
+end


### PR DESCRIPTION
Adds a rake task that can be included like:

`require 'metadata-json-lint/rake_task'
which exposes the`metadata_lint` task
