### PR TITLE
Fix currently failing, but green tests

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -86,7 +86,7 @@ module MetadataJsonLint
     # Shoulds/recommendations
     # From: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
 
-    if !parsed['license'].nil? && !SpdxLicenses.exist?(parsed['license']) && !parsed['license'] <=> "proprietary"
+    if !parsed['license'].nil? && !SpdxLicenses.exist?(parsed['license']) && parsed['license'] != "proprietary"
       puts "Warning: License identifier #{parsed['license']} is not in the SPDX list: http://spdx.org/licenses/"
       error_state = true if options[:strict_license]
     end

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,19 +12,18 @@ fail() {
 test() {
   name=$1; shift
   expect=$1; shift
-  (
-    cd $name
-    ../../bin/metadata-json-lint $* metadata.json >/dev/null 2>&1
-    RESULT=$?
-    if [ $RESULT -ne $expect ]; then
-        fail "Failing Test '${name}' (bin)"
-    fi
-    rake metadata_lint >/dev/null 2>&1
-    RESULT=$?
-    if [ $RESULT -ne $expect ]; then
-        fail "Failing Test '${name}' (rake)"
-    fi
-  )
+  cd $name
+  ../../bin/metadata-json-lint $* metadata.json >/dev/null 2>&1
+  RESULT=$?
+  if [ $RESULT -ne $expect ]; then
+      fail "Failing Test '${name}' (bin)"
+  fi
+  rake metadata_lint >/dev/null 2>&1
+  RESULT=$?
+  if [ $RESULT -ne $expect ]; then
+      fail "Failing Test '${name}' (rake)"
+  fi
+  cd ..
 }
 
 # Run a broken one, expect FAILURE
@@ -55,24 +54,22 @@ test "long_summary" $FAILURE
 test "proprietary" $SUCCESS
 
 # Run a broken one, expect SUCCESS
-(
-  cd duplicate-dep
-  ../../bin/metadata-json-lint --no-fail-on-warnings metadata.json >/dev/null 2>&1
-  RESULT=$?
-  if [ $RESULT -ne $SUCCESS ]; then
-      fail "Failing Test 'duplicate-dep' with --no-fail-on-warnings"
-  fi
-)
+cd duplicate-dep
+../../bin/metadata-json-lint --no-fail-on-warnings metadata.json >/dev/null 2>&1
+RESULT=$?
+if [ $RESULT -ne $SUCCESS ]; then
+    fail "Failing Test 'duplicate-dep' with --no-fail-on-warnings"
+fi
+cd ..
 
 # Run a broken one, expect SUCCESS
-(
-  cd bad_license
-  ../../bin/metadata-json-lint --no-strict-license metadata.json >/dev/null 2>&1
-  RESULT=$?
-  if [ $RESULT -ne $SUCCESS ]; then
-      fail "Failing Test 'bad_license' with --no-strict-license"
-  fi
-)
+cd bad_license
+../../bin/metadata-json-lint --no-strict-license metadata.json >/dev/null 2>&1
+RESULT=$?
+if [ $RESULT -ne $SUCCESS ]; then
+    fail "Failing Test 'bad_license' with --no-strict-license"
+fi
+cd ..
 
 # Run a broken one, expect SUCCESS
 # Testing on no file given


### PR DESCRIPTION
My changes to test.sh in 70c5620 to make it report a non-zero exit didn't work, as the change to STATUS was happening in a subshell.  Run test.sh or check recent Travis CI runs and you'll see it's failing, but remaining green.

This fixes test.sh and then the bug triggering failed tests.